### PR TITLE
Use absolute path to node_modules instead of ~

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const loaderUtils = require('loader-utils');
+const path = require('path');
 
 module.exports = function(source) {
   const query = loaderUtils.getOptions ? loaderUtils.getOptions(this) : loaderUtils.parseQuery(this.query);
@@ -6,8 +7,9 @@ module.exports = function(source) {
   const theme = query.theme;
   const base = query.base;
 
-  const themeVarsStr = theme ? `@import "~${theme}/variables.scss";\n` : '';
-  const baseVarsStr = base ? `@import "~${base}/variables.scss";\n` : ''; 
+  // resolve to node_modules of cwd
+  const themeVarsStr = `@import "${path.resolve(process.cwd(), 'node_modules', theme, 'variables.scss')}";\n`
+  const baseVarsStr = base ? `@import "${path.resolve(process.cwd(), 'node_modules', base, 'variables.scss')}";\n` : '';
 
   const modifyVars = query.modifyVars;
   let modifyVarsStr = '';

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = function(source) {
   const base = query.base;
 
   // resolve to node_modules of cwd
-  const themeVarsStr = `@import "${path.resolve(process.cwd(), 'node_modules', theme, 'variables.scss')}";\n`
+  const themeVarsStr = theme ? `@import "${path.resolve(process.cwd(), 'node_modules', theme, 'variables.scss')}";\n` : '';
   const baseVarsStr = base ? `@import "${path.resolve(process.cwd(), 'node_modules', base, 'variables.scss')}";\n` : '';
 
   const modifyVars = query.modifyVars;


### PR DESCRIPTION
Use absolute path of node_modules instead of ~

Otherwise it won't work with mini-css-extract-plugin and @ali/additional-style-webpack-plugin